### PR TITLE
feature: link to apn sketch on ds100 code

### DIFF
--- a/main.css
+++ b/main.css
@@ -24,6 +24,12 @@ td {
     padding-bottom: 0.5em;
 }
 
+.rl100Code a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: bold;
+}
+
 .rl100TypeLong {
     text-align: right;
 }

--- a/main.js
+++ b/main.js
@@ -144,7 +144,11 @@ function updateDom(items, amount) {
 
         const rl100Code = document.createElement("td");
         rl100Code.setAttribute("class", "rl100Code");
-        rl100Code.textContent = item["RL100-Code"];
+        const rl100CodeLink = document.createElement("a");
+        rl100CodeLink.textContent = item["RL100-Code"];
+        rl100CodeLink.href = `https://trassenfinder.de/api/web/infrastrukturen/5/dokumente/${item["RL100-Code"]}_APN-Skizze.pdf`;
+        rl100CodeLink.target = "_blank";
+        rl100Code.appendChild(rl100CodeLink);
 
         const rl100LongName = document.createElement("td");
         rl100LongName.setAttribute("class", "rl100LongName");


### PR DESCRIPTION
it's kinda complicated to find the apn sketch on trassenfinder.de from a station so I think it would be really useful to add this link here. The ds100 code should be also displayed bold ig.